### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,1044 @@
-# Git integration for Visual Studio Code
+# GitHub Codespaces ♥️ React
 
-**Notice:** This extension is bundled with Visual Studio Code. It can be disabled but not uninstalled.
+Welcome to your shiny new Codespace running React! We've got everything fired up and running for you to explore React.
 
-## Features
+You've got a blank canvas to work on from a git perspective as well. There's a single initial commit with the what you're seeing right now - where you go from here is up to you!
 
-See [Git support in VS Code](https://code.visualstudio.com/docs/editor/versioncontrol#_git-support) to learn about the features of this extension.
+Everything you do here is contained within this one codespace. There is no repository on GitHub yet. If and when you’re ready you can click "Publish Branch" and we’ll create your repository and push up your project. If you were just exploring then and have no further need for this code then you can simply delete your codespace and it's gone forever.
 
-## API
+This project was bootstrapped for you with [Create React App](https://github.com/facebook/create-react-app).
 
-The Git extension exposes an API, reachable by any other extension.
+## Available Scripts
 
-1. Copy `src/api/git.d.ts` to your extension's sources;
-2. Include `git.d.ts` in your extension's compilation.
-3. Get a hold of the API with the following snippet:
+In the project directory, you can run:
 
-	```ts
-	const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git').exports;
-	const git = gitExtension.getAPI(1);
-	```
-	**Note:** To ensure that the `vscode.git` extension is activated before your extension, add `extensionDependencies` ([docs](https://code.visualstudio.com/api/references/extension-manifest)) into the `package.json` of your extension:
-	```json
-	"extensionDependencies": [
-		"vscode.git"
-	]
-	```
+### `npm start`
+
+We've already run this for you in the `Codespaces: server` terminal window below. If you need to stop the server for any reason you can just run `npm start` again to bring it back online.
+
+Runs the app in the development mode.\
+Open [http://localhost:3000](http://localhost:3000) in the built-in Simple Browser (`Cmd/Ctrl + Shift + P > Simple Browser: Show`) to view your running application.
+
+The page will reload automatically when you make changes.\
+You may also see any lint errors in the console.
+
+### `npm test`
+
+Launches the test runner in the interactive watch mode.\
+See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+
+### `npm run build`
+
+Builds the app for production to the `build` folder.\
+It correctly bundles React in production mode and optimizes the build for the best performance.
+
+The build is minified and the filenames include the hashes.\
+Your app is ready to be deployed!
+
+See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+### `npm run eject`
+
+**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+
+If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+
+Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
+
+You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
+
+## Learn More
+
+You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+
+To learn React, check out the [React documentation](https://reactjs.org/).
+
+### Code Splitting
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
+
+### Analyzing the Bundle Size
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
+
+### Making a Progressive Web App
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
+
+### Advanced Configuration
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
+
+### Deployment
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
+
+### `npm run build` fails to minify
+
+This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+# Building Node.js
+
+Depending on what platform or features you need, the build process may
+differ. After you've built a binary, running the
+test suite to confirm that the binary works as intended is a good next step.
+
+If you can reproduce a test failure, search for it in the
+[Node.js issue tracker](https://github.com/nodejs/node/issues) or
+file a new issue.
+
+## Table of contents
+
+* [Supported platforms](#supported-platforms)
+  * [Input](#input)
+  * [Strategy](#strategy)
+  * [Platform list](#platform-list)
+  * [Supported toolchains](#supported-toolchains)
+  * [Official binary platforms and toolchains](#official-binary-platforms-and-toolchains)
+    * [OpenSSL asm support](#openssl-asm-support)
+  * [Previous versions of this document](#previous-versions-of-this-document)
+* [Building Node.js on supported platforms](#building-nodejs-on-supported-platforms)
+  * [Prerequisites](#prerequisites)
+  * [Unix and macOS](#unix-and-macos)
+    * [Unix prerequisites](#unix-prerequisites)
+    * [macOS prerequisites](#macos-prerequisites)
+    * [Building Node.js](#building-nodejs-1)
+    * [Installing Node.js](#installing-nodejs)
+    * [Running Tests](#running-tests)
+    * [Running Coverage](#running-coverage)
+    * [Building the documentation](#building-the-documentation)
+    * [Building a debug build](#building-a-debug-build)
+    * [Building an ASan build](#building-an-asan-build)
+    * [Speeding up frequent rebuilds when developing](#speeding-up-frequent-rebuilds-when-developing)
+    * [Troubleshooting Unix and macOS builds](#troubleshooting-unix-and-macos-builds)
+  * [Windows](#windows)
+    * [Windows Prerequisites](#windows-prerequisites)
+      * [Option 1: Manual install](#option-1-manual-install)
+      * [Option 2: Automated install with Boxstarter](#option-2-automated-install-with-boxstarter)
+    * [Building Node.js](#building-nodejs-2)
+  * [Android](#android)
+* [`Intl` (ECMA-402) support](#intl-ecma-402-support)
+  * [Build with full ICU support (all locales supported by ICU)](#build-with-full-icu-support-all-locales-supported-by-icu)
+    * [Unix/macOS](#unixmacos)
+    * [Windows](#windows-1)
+  * [Trimmed: `small-icu` (English only) support](#trimmed-small-icu-english-only-support)
+    * [Unix/macOS](#unixmacos-1)
+    * [Windows](#windows-2)
+  * [Building without Intl support](#building-without-intl-support)
+    * [Unix/macOS](#unixmacos-2)
+    * [Windows](#windows-3)
+  * [Use existing installed ICU (Unix/macOS only)](#use-existing-installed-icu-unixmacos-only)
+  * [Build with a specific ICU](#build-with-a-specific-icu)
+    * [Unix/macOS](#unixmacos-3)
+    * [Windows](#windows-4)
+* [Configuring OpenSSL config appname](#configure-openssl-appname)
+* [Building Node.js with FIPS-compliant OpenSSL](#building-nodejs-with-fips-compliant-openssl)
+* [Building Node.js with external core modules](#building-nodejs-with-external-core-modules)
+  * [Unix/macOS](#unixmacos-4)
+  * [Windows](#windows-5)
+* [Note for downstream distributors of Node.js](#note-for-downstream-distributors-of-nodejs)
+
+## Supported platforms
+
+This list of supported platforms is current as of the branch/release to
+which it belongs.
+
+### Input
+
+Node.js relies on V8 and libuv. We adopt a subset of their supported platforms.
+
+### Strategy
+
+There are three support tiers:
+
+* **Tier 1**: These platforms represent the majority of Node.js users. The
+  Node.js Build Working Group maintains infrastructure for full test coverage.
+  Test failures on tier 1 platforms will block releases.
+* **Tier 2**: These platforms represent smaller segments of the Node.js user
+  base. The Node.js Build Working Group maintains infrastructure for full test
+  coverage. Test failures on tier 2 platforms will block releases.
+  Infrastructure issues may delay the release of binaries for these platforms.
+* **Experimental**: May not compile or test suite may not pass. The core team
+  does not create releases for these platforms. Test failures on experimental
+  platforms do not block releases. Contributions to improve support for these
+  platforms are welcome.
+
+Platforms may move between tiers between major release lines. The table below
+will reflect those changes.
+
+### Platform list
+
+Node.js compilation/execution support depends on operating system, architecture,
+and libc version. The table below lists the support tier for each supported
+combination. A list of [supported compile toolchains](#supported-toolchains) is
+also supplied for tier 1 platforms.
+
+**For production applications, run Node.js on supported platforms only.**
+
+Node.js does not support a platform version if a vendor has expired support
+for it. In other words, Node.js does not support running on End-of-Life (EoL)
+platforms. This is true regardless of entries in the table below.
+
+| Operating System | Architectures    | Versions                          | Support Type                                    | Notes                                |
+| ---------------- | ---------------- | --------------------------------- | ----------------------------------------------- | ------------------------------------ |
+| GNU/Linux        | x64              | kernel >= 4.18[^1], glibc >= 2.28 | Tier 1                                          | e.g. Ubuntu 20.04, Debian 10, RHEL 8 |
+| GNU/Linux        | x64              | kernel >= 3.10, musl >= 1.1.19    | Experimental                                    | e.g. Alpine 3.8                      |
+| GNU/Linux        | x86              | kernel >= 3.10, glibc >= 2.17     | Experimental                                    | Downgraded as of Node.js 10          |
+| GNU/Linux        | arm64            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 1                                          | e.g. Ubuntu 20.04, Debian 10, RHEL 8 |
+| GNU/Linux        | armv7            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 1                                          | e.g. Ubuntu 20.04, Debian 11         |
+| GNU/Linux        | armv6            | kernel >= 4.14, glibc >= 2.24     | Experimental                                    | Downgraded as of Node.js 12          |
+| GNU/Linux        | ppc64le >=power8 | kernel >= 4.18[^1], glibc >= 2.28 | Tier 2                                          | e.g. Ubuntu 20.04, RHEL 8            |
+| GNU/Linux        | s390x            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 2                                          | e.g. RHEL 8                          |
+| GNU/Linux        | loong64          | kernel >= 5.19, glibc >= 2.36     | Experimental                                    |                                      |
+| Windows          | x64, x86 (WoW64) | >= Windows 10/Server 2016         | Tier 1                                          | [^2],[^3]                            |
+| Windows          | x86 (native)     | >= Windows 10/Server 2016         | Tier 1 (running) / Experimental (compiling)[^4] |                                      |
+| Windows          | x64, x86         | Windows 8.1/Server 2012           | Experimental                                    |                                      |
+| Windows          | arm64            | >= Windows 10                     | Tier 2                                          |                                      |
+| macOS            | x64              | >= 11.0                           | Tier 1                                          | For notes about compilation see [^5] |
+| macOS            | arm64            | >= 11.0                           | Tier 1                                          |                                      |
+| SmartOS          | x64              | >= 18                             | Tier 2                                          |                                      |
+| AIX              | ppc64be >=power8 | >= 7.2 TL04                       | Tier 2                                          |                                      |
+| FreeBSD          | x64              | >= 13.2                           | Experimental                                    |                                      |
+
+<!--lint disable final-definition-->
+
+[^1]: Older kernel versions may work. However, official Node.js release
+    binaries are [built on RHEL 8 systems](#official-binary-platforms-and-toolchains)
+    with kernel 4.18.
+
+[^2]: On Windows, running Node.js in Windows terminal emulators
+    like `mintty` requires the usage of [winpty](https://github.com/rprichard/winpty)
+    for the tty channels to work (e.g. `winpty node.exe script.js`).
+    In "Git bash" if you call the node shell alias (`node` without the `.exe`
+    extension), `winpty` is used automatically.
+
+[^3]: The Windows Subsystem for Linux (WSL) is not
+    supported, but the GNU/Linux build process and binaries should work. The
+    community will only address issues that reproduce on native GNU/Linux
+    systems. Issues that only reproduce on WSL should be reported in the
+    [WSL issue tracker](https://github.com/Microsoft/WSL/issues). Running the
+    Windows binary (`node.exe`) in WSL will not work without workarounds such as
+    stdio redirection.
+
+[^4]: Running Node.js on x86 Windows should work and binaries
+    are provided. However, tests in our infrastructure only run on WoW64.
+    Furthermore, compiling on x86 Windows is Experimental and
+    may not be possible.
+
+[^5]: Our macOS x64 Binaries are compiled with 11.0 as a target. Xcode 13 is
+    required to compile.
+
+<!--lint enable final-definition-->
+
+### Supported toolchains
+
+Depending on the host platform, the selection of toolchains may vary.
+
+| Operating System | Compiler Versions                                              |
+| ---------------- | -------------------------------------------------------------- |
+| Linux            | GCC >= 10.1                                                    |
+| Windows          | Visual Studio >= 2022 with the Windows 10 SDK on a 64-bit host |
+| macOS            | Xcode >= 13 (Apple LLVM >= 12)                                 |
+
+### Official binary platforms and toolchains
+
+Binaries at <https://nodejs.org/download/release/> are produced on:
+
+| Binary package          | Platform and Toolchain                                                                                      |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 10                                                                         |
+| darwin-x64              | macOS 11, Xcode 13 with -mmacosx-version-min=11.0                                                           |
+| darwin-arm64 (and .pkg) | macOS 11 (arm64), Xcode 13 with -mmacosx-version-min=11.0                                                   |
+| linux-arm64             | RHEL 8 with GCC 10[^6]                                                                                      |
+| linux-armv7l            | Cross-compiled on RHEL 8 x64 with [custom GCC toolchain](https://github.com/rvagg/rpi-newer-crosstools)[^7] |
+| linux-ppc64le           | RHEL 8 with gcc-toolset-10[^6]                                                                              |
+| linux-s390x             | RHEL 8 with gcc-toolset-10[^6]                                                                              |
+| linux-x64               | RHEL 8 with gcc-toolset-10[^6]                                                                              |
+| win-x64 and win-x86     | Windows Server 2022 (x64) with Visual Studio 2022                                                           |
+
+<!--lint disable final-definition-->
+
+[^6]: Binaries produced on these systems are compatible with glibc >= 2.28
+    and libstdc++ >= 6.0.25 (`GLIBCXX_3.4.25`). These are available on
+    distributions natively supporting GCC 8.1 or higher, such as Debian 10,
+    RHEL 8 and Ubuntu 20.04.
+
+[^7]: Binaries produced on these systems are compatible with glibc >= 2.28
+    and libstdc++ >= 6.0.28 (`GLIBCXX_3.4.28`). These are available on
+    distributions natively supporting GCC 9.3 or higher, such as Debian 11,
+    Ubuntu 20.04.
+
+<!--lint enable final-definition-->
+
+#### OpenSSL asm support
+
+OpenSSL-1.1.1 requires the following assembler version for use of asm
+support on x86\_64 and ia32.
+
+For use of AVX-512,
+
+* gas (GNU assembler) version 2.26 or higher
+* nasm version 2.11.8 or higher in Windows
+
+AVX-512 is disabled for Skylake-X by OpenSSL-1.1.1.
+
+For use of AVX2,
+
+* gas (GNU assembler) version 2.23 or higher
+* Xcode version 5.0 or higher
+* llvm version 3.3 or higher
+* nasm version 2.10 or higher in Windows
+
+Please refer to <https://docs.openssl.org/1.1.1/man3/OPENSSL_ia32cap/> for details.
+
+If compiling without one of the above, use `configure` with the
+`--openssl-no-asm` flag. Otherwise, `configure` will fail.
+
+### Previous versions of this document
+
+Supported platforms and toolchains change with each major version of Node.js.
+This document is only valid for the current major version of Node.js.
+Consult previous versions of this document for older versions of Node.js:
+
+* [Node.js 21](https://github.com/nodejs/node/blob/v21.x/BUILDING.md)
+* [Node.js 20](https://github.com/nodejs/node/blob/v20.x/BUILDING.md)
+* [Node.js 18](https://github.com/nodejs/node/blob/v18.x/BUILDING.md)
+
+## Building Node.js on supported platforms
+
+### Prerequisites
+
+* [A supported version of Python][Python versions] for building and testing.
+* Memory: at least 8GB of RAM is typically required when compiling with 4 parallel jobs (e.g: `make -j4`)
+
+### Unix and macOS
+
+#### Unix prerequisites
+
+* `gcc` and `g++` >= 10.1 or newer
+* GNU Make 3.81 or newer
+* [A supported version of Python][Python versions]
+  * For test coverage, your Python installation must include pip.
+
+Installation via Linux package manager can be achieved with:
+
+* Ubuntu, Debian: `sudo apt-get install python3 g++ make python3-pip`
+* Fedora: `sudo dnf install python3 gcc-c++ make python3-pip`
+* CentOS and RHEL: `sudo yum install python3 gcc-c++ make python3-pip`
+* OpenSUSE: `sudo zypper install python3 gcc-c++ make python3-pip`
+* Arch Linux, Manjaro: `sudo pacman -S python gcc make python-pip`
+
+FreeBSD and OpenBSD users may also need to install `libexecinfo`.
+
+#### macOS prerequisites
+
+* Xcode Command Line Tools >= 13 for macOS
+* [A supported version of Python][Python versions]
+  * For test coverage, your Python installation must include pip.
+
+macOS users can install the `Xcode Command Line Tools` by running
+`xcode-select --install`. Alternatively, if you already have the full Xcode
+installed, you can find them under the menu `Xcode -> Open Developer Tool ->
+More Developer Tools...`. This step will install `clang`, `clang++`, and
+`make`.
+
+#### Building Node.js
+
+If the path to your build directory contains a space, the build will likely
+fail.
+
+To build Node.js:
+
+```bash
+./configure
+make -j4
+```
+
+We can speed up the builds by using [Ninja](https://ninja-build.org/). For more
+information, see
+[Building Node.js with Ninja](doc/contributing/building-node-with-ninja.md).
+
+The `-j4` option will cause `make` to run 4 simultaneous compilation jobs which
+may reduce build time. For more information, see the
+[GNU Make Documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html).
+
+The above requires that `python` resolves to a supported version of
+Python. See [Prerequisites](#prerequisites).
+
+After building, setting up [firewall rules](tools/macos-firewall.sh) can avoid
+popups asking to accept incoming network connections when running tests.
+
+Running the following script on macOS will add the firewall rules for the
+executable `node` in the `out` directory and the symbolic `node` link in the
+project's root directory.
+
+```bash
+sudo ./tools/macos-firewall.sh
+```
+
+#### Installing Node.js
+
+To install this version of Node.js into a system directory:
+
+```bash
+[sudo] make install
+```
+
+#### Running tests
+
+To verify the build:
+
+```bash
+make test-only
+```
+
+At this point, you are ready to make code changes and re-run the tests.
+
+If you are running tests before submitting a pull request, use:
+
+```bash
+make -j4 test
+```
+
+`make -j4 test` does a full check on the codebase, including running linters and
+documentation tests.
+
+To run the linter without running tests, use
+`make lint`/`vcbuild lint`. It will lint JavaScript, C++, and Markdown files.
+
+To fix auto fixable JavaScript linting errors, use `make lint-js-fix`.
+
+If you are updating tests and want to run tests in a single test file
+(e.g. `test/parallel/test-stream2-transform.js`):
+
+```bash
+tools/test.py test/parallel/test-stream2-transform.js
+```
+
+You can execute the entire suite of tests for a given subsystem
+by providing the name of a subsystem:
+
+```bash
+tools/test.py child-process
+```
+
+You can also execute the tests in a test suite directory
+(such as `test/message`):
+
+```bash
+tools/test.py test/message
+```
+
+If you want to check the other options, please refer to the help by using
+the `--help` option:
+
+```bash
+tools/test.py --help
+```
+
+> Note: On Windows you should use `python3` executable.
+> Example: `python3 tools/test.py test/message`
+
+You can usually run tests directly with node:
+
+```bash
+./node test/parallel/test-stream2-transform.js
+```
+
+> Info: `./node` points to your local Node.js build.
+
+Remember to recompile with `make -j4` in between test runs if you change code in
+the `lib` or `src` directories.
+
+The tests attempt to detect support for IPv6 and exclude IPv6 tests if
+appropriate. If your main interface has IPv6 addresses, then your
+loopback interface must also have '::1' enabled. For some default installations
+on Ubuntu, that does not seem to be the case. To enable '::1' on the
+loopback interface on Ubuntu:
+
+```bash
+sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0
+```
+
+You can use
+[node-code-ide-configs](https://github.com/nodejs/node-code-ide-configs)
+to run/debug tests if your IDE configs are present.
+
+#### Running coverage
+
+It's good practice to ensure any code you add or change is covered by tests.
+You can do so by running the test suite with coverage enabled:
+
+```bash
+./configure --coverage
+make coverage
+```
+
+A detailed coverage report will be written to `coverage/index.html` for
+JavaScript coverage and to `coverage/cxxcoverage.html` for C++ coverage.
+
+If you only want to run the JavaScript tests then you do not need to run
+the first command (`./configure --coverage`). Run `make coverage-run-js`,
+to execute JavaScript tests independently of the C++ test suite:
+
+```bash
+make coverage-run-js
+```
+
+If you are updating tests and want to collect coverage for a single test file
+(e.g. `test/parallel/test-stream2-transform.js`):
+
+```bash
+make coverage-clean
+NODE_V8_COVERAGE=coverage/tmp tools/test.py test/parallel/test-stream2-transform.js
+make coverage-report-js
+```
+
+You can collect coverage for the entire suite of tests for a given subsystem
+by providing the name of a subsystem:
+
+```bash
+make coverage-clean
+NODE_V8_COVERAGE=coverage/tmp tools/test.py --mode=release child-process
+make coverage-report-js
+```
+
+The `make coverage` command downloads some tools to the project root directory.
+To clean up after generating the coverage reports:
+
+```bash
+make coverage-clean
+```
+
+#### Building the documentation
+
+To build the documentation:
+
+This will build Node.js first (if necessary) and then use it to build the docs:
+
+```bash
+make doc
+```
+
+If you have an existing Node.js build, you can build just the docs with:
+
+```bash
+NODE=/path/to/node make doc-only
+```
+
+To read the man page:
+
+```bash
+man doc/node.1
+```
+
+If you prefer to read the full documentation in a browser, run the following.
+
+```bash
+make docserve
+```
+
+This will spin up a static file server and provide a URL to where you may browse
+the documentation locally.
+
+If you're comfortable viewing the documentation using the program your operating
+system has associated with the default web browser, run the following.
+
+```bash
+make docopen
+```
+
+This will open a file URL to a one-page version of all the browsable HTML
+documents using the default browser.
+
+```bash
+make docclean
+```
+
+This will clean previously built doc.
+
+To test if Node.js was built correctly:
+
+```bash
+./node -e "console.log('Hello from Node.js ' + process.version)"
+```
+
+#### Building a debug build
+
+If you run into an issue where the information provided by the JS stack trace
+is not enough, or if you suspect the error happens outside of the JS VM, you
+can try to build a debug enabled binary:
+
+```bash
+./configure --debug
+make -j4
+```
+
+`make` with `./configure --debug` generates two binaries, the regular release
+one in `out/Release/node` and a debug binary in `out/Debug/node`, only the
+release version is actually installed when you run `make install`.
+
+To use the debug build with all the normal dependencies overwrite the release
+version in the install directory:
+
+```bash
+make install PREFIX=/opt/node-debug/
+cp -a -f out/Debug/node /opt/node-debug/node
+```
+
+When using the debug binary, core dumps will be generated in case of crashes.
+These core dumps are useful for debugging when provided with the
+corresponding original debug binary and system information.
+
+Reading the core dump requires `gdb` built on the same platform the core dump
+was captured on (i.e. 64-bit `gdb` for `node` built on a 64-bit system, Linux
+`gdb` for `node` built on Linux) otherwise you will get errors like
+`not in executable format: File format not recognized`.
+
+Example of generating a backtrace from the core dump:
+
+```bash
+$ gdb /opt/node-debug/node core.node.8.1535359906
+(gdb) backtrace
+```
+
+#### Building an ASan build
+
+[ASan](https://github.com/google/sanitizers) can help detect various memory
+related bugs. ASan builds are currently only supported on linux.
+If you want to check it on Windows or macOS or you want a consistent toolchain
+on Linux, you can try [Docker](https://www.docker.com/products/docker-desktop/)
+(using an image like `gengjiawen/node-build:2020-02-14`).
+
+The `--debug` is not necessary and will slow down build and testing, but it can
+show clear stacktrace if ASan hits an issue.
+
+```bash
+./configure --debug --enable-asan && make -j4
+make test-only
+```
+
+#### Speeding up frequent rebuilds when developing
+
+Tips: The `ccache` utility is widely used and should generally work fine.
+If you encounter any difficulties, consider disabling `mold` as a
+troubleshooting step.
+
+If you plan to frequently rebuild Node.js, especially if using several
+branches, installing `ccache` can help to greatly reduce build
+times. Set up with:
+
+On GNU/Linux:
+
+Tips: `mold` can speed up the link process, which can't be cached, you may
+need to install the latest version but not the apt version.
+
+```bash
+sudo apt install ccache mold   # for Debian/Ubuntu, included in most Linux distros
+export CC="ccache gcc"         # add to your .profile
+export CXX="ccache g++"        # add to your .profile
+export LDFLAGS="-fuse-ld=mold" # add to your .profile
+```
+
+Refs:
+
+1. <https://ccache.dev/performance.html>
+2. <https://github.com/rui314/mold>
+
+On macOS:
+
+```bash
+brew install ccache            # see https://brew.sh
+export CC="ccache cc"          # add to ~/.zshrc or other shell config file
+export CXX="ccache c++"        # add to ~/.zshrc or other shell config file
+```
+
+This will allow for near-instantaneous rebuilds when switching branches back
+and forth that were built with cache.
+
+When modifying only the JS layer in `lib`, it is possible to externally load it
+without modifying the executable:
+
+```bash
+./configure --node-builtin-modules-path "$(pwd)"
+```
+
+The resulting binary won't include any JS files and will try to load them from
+the specified directory. The JS debugger of Visual Studio Code supports this
+configuration since the November 2020 version and allows for setting
+breakpoints.
+
+#### Troubleshooting Unix and macOS builds
+
+Stale builds can sometimes result in `file not found` errors while building.
+This and some other problems can be resolved with `make distclean`. The
+`distclean` recipe aggressively removes build artifacts. You will need to
+build again (`make -j4`). Since all build artifacts have been removed, this
+rebuild may take a lot more time than previous builds. Additionally,
+`distclean` removes the file that stores the results of `./configure`. If you
+ran `./configure` with non-default options (such as `--debug`), you will need
+to run it again before invoking `make -j4`.
+
+If you received the error `nodejs g++ fatal error compilation terminated cc1plus`
+during compilation, this is likely a memory issue and you should either provide
+more RAM or create swap space to accommodate toolchain requirements or reduce
+the number of parallel build tasks (`-j<n>`).
+
+### Windows
+
+#### Tips
+
+You may need disable vcpkg integration if you got link error about symbol
+redefine related to zlib.lib(zlib1.dll), even you never install it by hand,
+as vcpkg is part of CLion and Visual Studio now.
+
+```powershell
+# find your vcpkg
+# double check vcpkg install the related file
+vcpkg owns zlib.lib
+vcpkg owns zlib1.dll
+vcpkg integrate remove
+```
+
+Refs:
+
+1. <https://github.com/nodejs/node/issues/24448>
+2. <https://github.com/microsoft/vcpkg/issues/37518> / <https://github.com/microsoft/vcpkg/discussions/37546>
+3. [vcpkg](https://github.com/microsoft/vcpkg/)
+
+#### Windows Prerequisites
+
+##### Option 1: Manual install
+
+* The current [version of Python][Python versions] from the
+  [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation)
+* The "Desktop development with C++" workload from
+  [Visual Studio 2022 (17.6 or newer)](https://visualstudio.microsoft.com/downloads/)
+  or the "C++ build tools" workload from the
+  [Build Tools](https://aka.ms/vs/17/release/vs_buildtools.exe),
+  with the default optional components
+* Basic Unix tools required for some tests,
+  [Git for Windows](https://git-scm.com/download/win) includes Git Bash
+  and tools which can be included in the global `PATH`.
+* The [NetWide Assembler](https://www.nasm.us/), for OpenSSL assembler modules.
+  If not installed in the default location, it needs to be manually added
+  to `PATH`. A build with the `openssl-no-asm` option does not need this, nor
+  does a build targeting ARM64 Windows.
+
+Optional requirements to build the MSI installer package:
+
+* The .NET SDK component from [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)
+  * This component can be installed via the Visual Studio Installer Application
+
+Optional requirements for compiling for Windows on ARM (ARM64):
+
+* Visual Studio 17.6.0 or newer
+  > **Note:** There is [a bug](https://github.com/nodejs/build/issues/3739) in `17.10.x`
+  > preventing Node.js from compiling.
+* Visual Studio optional components
+  * Visual C++ compilers and libraries for ARM64
+  * Visual C++ ATL for ARM64
+* Windows 10 SDK 10.0.17763.0 or newer
+
+Optional requirements for compiling with ClangCL:
+
+* Visual Studio optional components
+  * C++ Clang Compiler for Windows
+  * MSBuild support for LLVM toolset
+
+NOTE: Currently we only support compiling with Clang that comes from Visual Studio.
+
+##### Option 2: Automated install with Boxstarter
+
+A [Boxstarter](https://boxstarter.org/) script can be used for easy setup of
+Windows systems with all the required prerequisites for Node.js development.
+This script will install the following [Chocolatey](https://chocolatey.org/)
+packages:
+
+* [Git for Windows](https://chocolatey.org/packages/git) with the `git` and
+  Unix tools added to the `PATH`
+* [Python 3.x](https://chocolatey.org/packages/python)
+* [Visual Studio 2022 Build Tools](https://chocolatey.org/packages/visualstudio2022buildtools)
+  with [Visual C++ workload](https://chocolatey.org/packages/visualstudio2022-workload-vctools)
+* [NetWide Assembler](https://chocolatey.org/packages/nasm)
+
+To install Node.js prerequisites using
+[Boxstarter WebLauncher](https://boxstarter.org/weblauncher), visit
+<https://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/nodejs/node/HEAD/tools/bootstrap/windows_boxstarter>
+with a supported browser.
+
+Alternatively, you can use PowerShell. Run those commands from
+an elevated (Administrator) PowerShell terminal:
+
+```powershell
+Set-ExecutionPolicy Unrestricted -Force
+iex ((New-Object System.Net.WebClient).DownloadString('https://boxstarter.org/bootstrapper.ps1'))
+get-boxstarter -Force
+Install-BoxstarterPackage https://raw.githubusercontent.com/nodejs/node/HEAD/tools/bootstrap/windows_boxstarter -DisableReboots
+refreshenv
+```
+
+The entire installation using Boxstarter will take up approximately 10 GB of
+disk space.
+
+#### Building Node.js
+
+* Remember to first clone the Node.js repository with the Git command
+  and head to the directory that Git created; If you haven't already
+  ```powershell
+  git clone https://github.com/nodejs/node.git
+  cd node
+  ```
+
+> \[!TIP]
+> If you are building from a Windows machine, symlinks are disabled by default, and can be enabled by cloning
+> with the `-c core.symlinks=true` flag.
+>
+> ```powershell
+> git clone -c core.symlinks=true <repository_url>
+> ```
+
+* If the path to your build directory contains a space or a non-ASCII character,
+  the build will likely fail
+
+To start the build process:
+
+```powershell
+.\vcbuild
+```
+
+To run the tests:
+
+```powershell
+.\vcbuild test
+```
+
+To test if Node.js was built correctly:
+
+```powershell
+Release\node -e "console.log('Hello from Node.js', process.version)"
+```
+
+### Android
+
+Android is not a supported platform. Patches to improve the Android build are
+welcome. There is no testing on Android in the current continuous integration
+environment. The participation of people dedicated and determined to improve
+Android building, testing, and support is encouraged.
+
+Be sure you have downloaded and extracted
+[Android NDK](https://developer.android.com/ndk) before in
+a folder. Then run:
+
+```bash
+./android-configure <path to the Android NDK> <Android SDK version> <target architecture>
+make -j4
+```
+
+The Android SDK version should be at least 24 (Android 7.0) and the target
+architecture supports \[arm, arm64/aarch64, x86, x86\_64].
+
+## `Intl` (ECMA-402) support
+
+[Intl](doc/api/intl.md) support is
+enabled by default.
+
+### Build with full ICU support (all locales supported by ICU)
+
+This is the default option.
+
+#### Unix/macOS
+
+```bash
+./configure --with-intl=full-icu
+```
+
+#### Windows
+
+```powershell
+.\vcbuild full-icu
+```
+
+### Trimmed: `small-icu` (English only) support
+
+In this configuration, only English data is included, but
+the full `Intl` (ECMA-402) APIs. It does not need to download
+any dependencies to function. You can add full data at runtime.
+
+#### Unix/macOS
+
+```bash
+./configure --with-intl=small-icu
+```
+
+#### Windows
+
+```powershell
+.\vcbuild small-icu
+```
+
+### Building without Intl support
+
+The `Intl` object will not be available, nor some other APIs such as
+`String.normalize`.
+
+#### Unix/macOS
+
+```bash
+./configure --without-intl
+```
+
+#### Windows
+
+```powershell
+.\vcbuild without-intl
+```
+
+### Use existing installed ICU (Unix/macOS only)
+
+```bash
+pkg-config --modversion icu-i18n && ./configure --with-intl=system-icu
+```
+
+If you are cross-compiling, your `pkg-config` must be able to supply a path
+that works for both your host and target environments.
+
+### Build with a specific ICU
+
+You can find other ICU releases at
+[the ICU homepage](https://icu.unicode.org/download).
+Download the file named something like `icu4c-**##.#**-src.tgz` (or
+`.zip`).
+
+To check the minimum recommended ICU, run `./configure --help` and see
+the help for the `--with-icu-source` option. A warning will be printed
+during configuration if the ICU version is too old.
+
+#### Unix/macOS
+
+From an already-unpacked ICU:
+
+```bash
+./configure --with-intl=[small-icu,full-icu] --with-icu-source=/path/to/icu
+```
+
+From a local ICU tarball:
+
+```bash
+./configure --with-intl=[small-icu,full-icu] --with-icu-source=/path/to/icu.tgz
+```
+
+From a tarball URL:
+
+```bash
+./configure --with-intl=full-icu --with-icu-source=http://url/to/icu.tgz
+```
+
+#### Windows
+
+First unpack latest ICU to `deps/icu`
+[icu4c-**##.#**-src.tgz](https://icu.unicode.org/download) (or `.zip`)
+as `deps/icu` (You'll have: `deps/icu/source/...`)
+
+```powershell
+.\vcbuild full-icu
+```
+
+### Configure OpenSSL appname
+
+Node.js can use an OpenSSL configuration file by specifying the environment
+variable `OPENSSL_CONF`, or using the command line option `--openssl-conf`, and
+if none of those are specified will default to reading the default OpenSSL
+configuration file `openssl.cnf`. Node.js will only read a section that is by
+default named `nodejs_conf`, but this name can be overridden using the following
+configure option:
+
+```bash
+./configure --openssl-conf-name=<some_conf_name>
+```
+
+## Building Node.js with FIPS-compliant OpenSSL
+
+Node.js supports FIPS when statically or dynamically linked with OpenSSL 3 via
+[OpenSSL's provider model](https://docs.openssl.org/3.0/man7/crypto/#OPENSSL-PROVIDERS).
+It is not necessary to rebuild Node.js to enable support for FIPS.
+
+See [FIPS mode](doc/api/crypto.md#fips-mode) for more information on how to
+enable FIPS support in Node.js.
+
+## Building Node.js with external core modules
+
+It is possible to specify one or more JavaScript text files to be bundled in
+the binary as built-in modules when building Node.js.
+
+### Unix/macOS
+
+This command will make `/root/myModule.js` available via
+`require('/root/myModule')` and `./myModule2.js` available via
+`require('myModule2')`.
+
+```bash
+./configure --link-module '/root/myModule.js' --link-module './myModule2.js'
+```
+
+### Windows
+
+To make `./myModule.js` available via `require('myModule')` and
+`./myModule2.js` available via `require('myModule2')`:
+
+```powershell
+.\vcbuild link-module './myModule.js' link-module './myModule2.js'
+```
+
+## Building to use shared dependencies at runtime
+
+By default Node.js is built so that all dependencies are bundled into
+the Node.js binary itself. This provides a single binary that includes
+the correct versions of all dependencies on which it depends.
+
+Some Node.js distributions, however, prefer to manage dependencies.
+A number of `configure` options are provided to support this use case.
+
+* For dependencies with native code, the first set of options allow
+  Node.js to be built so that it uses a shared library
+  at runtime instead of building and including the dependency
+  in the Node.js binary itself. These options are in the
+  `Shared libraries` section of the `configure` help
+  (run `./configure --help` to get the complete list).
+  They provide the ability to enable the use of a shared library,
+  to set the name of the shared library, and to set the paths that
+  contain the include and shared library files.
+
+* For dependencies with JavaScript code (including WASM), the second
+  set of options allow the Node.js binary to be built so that it loads
+  the JavaScript for dependencies at runtime instead of being built into
+  the Node.js binary itself. These options are in the `Shared builtins`
+  section of the `configure` help
+  (run `./configure --help` to get the complete list). They
+  provide the ability to set the path to an external JavaScript file
+  for the dependency to be used at runtime.
+
+It is the responsibility of any distribution
+shipping with these options to:
+
+* ensure that the shared dependencies available at runtime
+  match what is expected by the Node.js binary. A
+  mismatch may result in crashes or unexpected behavior.
+* fully test that Node.js operates as expected with the
+  external dependencies. There may be little or no test coverage
+  within the Node.js project CI for these non-default options.
+
+## Note for downstream distributors of Node.js
+
+The Node.js ecosystem is reliant on ABI compatibility within a major release.
+To maintain ABI compatibility it is required that distributed builds of Node.js
+be built against the same version of dependencies, or similar versions that do
+not break their ABI compatibility, as those released by Node.js for any given
+`NODE_MODULE_VERSION` (located in `src/node_version.h`).
+
+When Node.js is built (with an intention to distribute) with an ABI
+incompatible with the official Node.js builds (e.g. using a ABI incompatible
+version of a dependency), please reserve and use a custom `NODE_MODULE_VERSION`
+by opening a pull request against the registry available at
+<https://github.com/nodejs/node/blob/HEAD/doc/abi_version_registry.json>.
+
+[Python versions]: https://devguide.python.org/versions/


### PR DESCRIPTION
# LHCb stack development tools

## Get started

First, choose and `cd` into a directory where your stack will reside,
for example, `$HOME` or `/afs/cern.ch/work/j/jdoe`.

> **Important:** You need at least **10 GiB** of free space to compile the stack for
> one `*-opt` platform, and **50 GiB** if you compile with debug symbols
> (`*-dbg` or `*-opt+g`).

> **Note:** Working on network file systems such as AFS or on network-backed
> volumes (e.g. on CERN OpenStack) is typically slower than on a local disk,
> especially if the latter is an SSD.

> **Note:** A good hybrid solution is to put the source code (few GiB) in your
> backed up home (e.g. AFS/NFS) and put the build artifacts in a bigger and faster
> local storage (that may not be backed up). See below how to do this using
> the [`buildPath`](#configuration-settings) setting.

Adjust the following command according to how you want the directory containing your stack to be called and then run it (here we use simply "`stack`"):

```sh
curl -sSL https://gitlab.cern.ch/lhcb-core/dev-tools/lb-stack-setup/raw/master/setup.py | python3 - stack
```

> **Note:** If your system lacks Python 3 (`/usr/bin/python3`), ask for it to
> be installed, or simply source the LHCb environment with
> `source /cvmfs/lhcb.cern.ch/lib/LbEnv` if it is not already sourced.

> **Note:** If you are working in the LHCb Online network (e.g. pluscc and __not__ lxplus),
> set up git with
> ```
> hostname --fqdn | grep -q lbdaq.cern.ch && git config --global 'http.https://github.com/.proxy' lbproxy01:8080
> ```
> to use the proxy to access GitHub.
> If you use VSCode with Remote - SSH , see also
> [doc/vscode.md](doc/vscode.md#using-remote-with-a-server-in-a-restricted-network)

The script will first check that all prerequisites are met. If it fails, check
[doc/prerequisites.md](doc/prerequisites.md) for more information.
Then it will clone this repo inside a new directory `stack/utils` and do the
initial setup. It will choose a default environment for you ("native" build on
CentOS 7 and docker on other OSes).

Configure your setup (e.g. desired platform) and projects to build

```sh
$EDITOR utils/config.json
```

All possible configuration settings and their defaults are stored in
[default-config.json](default-config.json).
Any settings you specify in the `config.json` file will override the defaults.
When you override dictionary values (e.g. `cmakeFlags`), the dictionary in
`config.json` will be merged with the one in `default-config.json`.
See [below](#configuration-settings) for some of the available settings and their use.

## Compile

You are now ready to go! Type `make [Project]` which will checkout all relevant
projects and build them. It can take some time.

```sh
make Moore
```

For example, building from Gaudi up until Moore takes 40 min on a mobile i5 CPU
with 2 physical cores.

## Run

Run jobs in the right environment with

```sh
utils/run-env Moore gaudirun.py #...
# or simply
Moore/run gaudirun.py #...
```

## Test

Below you see commands used in a typical testing workflow.

```sh
# make project and dependencies
make Moore  # or equivalently, make Moore/
# list available tests
make fast/Moore/test ARGS='-N'
# run all tests with 4 parallel jobs
make fast/Moore/test ARGS='-j 4'
# run test(s) matching a regex
make fast/Moore/test ARGS='-R hlt1_example$'
# verbose output showing test (failure) details
make fast/Moore/test ARGS='-R hlt1_example -V'
# running the mdf_read automatically runs the dependency mdf_write
make fast/Moore/test ARGS='-R mdf_read'
# to ignore all dependencies and only run mdf_read
make fast/Moore/test ARGS='-R mdf_read -FA .*'
```

Using `ARGS` you can pass arbitrary arguments to
[`ctest`](https://cmake.org/cmake/help/latest/manual/ctest.1.html).
Check the documentation for other useful arguments (e.g. `--stop-on-failure`
and `--rerun-failed`).

Note that changes in python sources are immediately "applied" in downstream projects
(unlike a "manual" stack setup with `lb-project-init`). For example, after changing a
`.py` in LHCb, you can do `Moore/run` or `make Moore/test ...` without having to
`make Moore` first.

> **Warning:** the above feature was broken by the new CMake, so for the time being
> always run `make Moore` after changes in upstream projects.
> See https://gitlab.cern.ch/lhcb-core/dev-tools/lb-stack-setup/-/issues/60

## Makefile instructions

The `Makefile` provided features the following targets.

- Global targets
  - `all` (or `build`): builds the default projects (this is the default target),
  - `clean`: remove build products for all cloned projects (keeping the sources and CMake cache),
  - `purge`: similar to `clean`, but also remove the CMake temporary files,
  - `update`: pull remote updates for repos which are on the default branch,
  - `help`: print a list of available targets,
  - `for-each CMD="do-something"`: run a command in each git repository (projects, data packages or other).
- Project targets
  - `<Project>`: build the required project (with dependencies),
  - `<Project>/`: same as the above,
  - `<Project>/<target>`: build the specified target in the given project,
    for example, to get the list of targets available in Gaudi you can call `make Gaudi/help`,
  - `<Project>-clean`: clean `<Project>` and the projects that depend on it
  - `fast/<Project>[/<target>]`: same as the target `<Project>[/<target>]`
    but do not try to build the dependencies,
  - `fast/<Project>/checkout`: just checkout `<Project>` without its dependencies.

## Monolithic builds (experimental)

Thanks to the modern CMake configuration, we can build all projects into
one monolithic build. Some pros of this way of build are:

- Save space and time by not copying files to InstallArea.
- Can set breakpoints in the sources in upstream projects (not in InstallArea).
- Jumping to definition (intellisense) leads to the sources.
- The overall configure time is shorter (but re-configuring always goes through all projects).

Enable the monolithic build by setting

```sh
utils/config.py monoBuild true
```

The `defaultProjects` setting is more important, it must contain the superset of
projects you work with (it defines which projects are configured).

The make targets are slightly different (no `fast/Project`, no `Project/purge`).
See `make help` for a complete list. _TODO_ describe targets in detail.
A typical workflow would be:

```sh
make Moore
make Moore/test ARGS='-N'
mono/run gaudirun.py ...
```

## Integrations

### Visual Studio Code

There is VS Code support via an auto-generated
[multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces)
configuration file (`stack.code-workspace`)
and per-project configuration files (`Project/.vscode/settings.json`).
The file is updated every time you run `make` and you can force an update
with `make stack.code-workspace` (e.g. in case you modified `template.code-workspace`).
Currently, intellisense for C++ and Python, and debugging configurations are supported.
There are no other integrations such as building and testing from within VS Code.
See [doc/vscode.md](doc/vscode.md) for more information, including some demos.

## Configuration settings

You can set the following options in `config.json` to configure your build setup.
Depending on what and where you build there are different recommendations.

- `binaryTag`: Default platform to use. The value is used to set the BINARY_TAG environment
  variable when building. The value can be overridden for a particular invocation of `make`
  with `make BINARY_TAG=<other binary tag> <target>`. Alternatively, set the value to an
  empty string in `config.json` and export it before running make: `BINARY_TAG=... make <target>`.
- `defaultProjects`: Defines which projects are built when `make` is invoked without giving any
  project-specific target (i.e. `make`, `make all` or `make build`).
- `buildPath` and `ccachePath`: Defines where the build artifacts are stored. By default, they
  are put under the stack directory (and the respective projects inside). Instead, you can put
  the artifacts in a separate directory/volume, with something like this:

    ```sh
    utils/config.py ccachePath '/localdisk1/$USER/ccache/$BINARY_TAG'
    utils/config.py buildPath  '/localdisk2/$USER/build/${projectPath}'
    ```

- `useDocker (true/false)`: Allows running with docker, check
  [doc/prerequisites.md](doc/prerequisites.md) for instructions.
  Defaults to false on CentOS7, otherwise is true.
- `distcc ([true]/false)`: distcc allows to compile remotely on machines located at CERN.
  Currently 80 virtual cores are available for parallel compilation.
  You need a valid kerberos token and connectivity to lxplus (or to be inside the CERN network).
  Be aware that these are shared resources, set it to `false` if your local cluster is powerful.
- `forwardEnv (list)`: A list of environment variables that should be propagated
  to the build and runtime environment. You may use it for variables such as `GITCONDDBPATH`.
- `vscodeWorkspaceSettings`: include custom VSCode settings in the `.code-workspace` file.
  For example, one can customize the color of the window title bar with

    ```json
    "vscodeWorkspaceSettings": {
      "workbench.colorCustomizations": {
        "titleBar.activeBackground": "#a75555",
        "titleBar.activeForeground": "#ffffff"
      }
    }
    ```

All possible configuration settings and their defaults are stored in
[default-config.json](default-config.json).

## HOWTOs

### Change the platform

The platform set in your shell when running `make` or `run-env` is irrelevant.
In order to change the platform used to compile and run, do the following

```sh
utils/config.py binaryTag x86_64_v3-centos7-gcc11-opt
```

or edit the file `utils/config.json` directly.

You can also temporarily override the `binaryTag` setting when running `make`
or the run scripts:

```sh
make BINARY_TAG=x86_64_v3-centos7-gcc11-opt Moore
BINARY_TAG_OVERRIDE=x86_64_v3-centos7-gcc11-opt Moore/run
```

### Use released versions of the software

It is possible to build only a part of stack by specifying the versions of
the direct dependencies to be picked up from CVMFS.

For example, if you want to build Moore on top of released Rec, Allen, etc.,
you can run

```sh
utils/config.py cvmfsProjects.Allen v3r22p1
```

which results in the following being added to `config.json`

```json
    "cvmfsProjects": {
        "Allen": "v3r22p1"
    }
```

To build MooreOnline but pick up Moore from CVMFS,
you need to specify the versions of Moore and LHCb
(because MooreOnline depends on Online, which (today) depends on LHCb).

```json
    "cvmfsProjects": {
        "Moore": "v54r22p3",
        "LHCb": "v54r21"
    }
```

> __Note:__ Don't forget to also set a `binaryTag` and an `lcgVersion`
> that make sense for the chosen versions.

### Add a data package

By default only [PRConfig](https://gitlab.cern.ch/lhcb-datapkg/PRConfig),
[AppConfig](https://gitlab.cern.ch/lhcb-datapkg/AppConfig) and
[ParamFiles](https://gitlab.cern.ch/lhcb-datapkg/ParamFiles) are cloned.
You can add a new package to be checked out in the json configuration.

> __Note:__ After adding a new data package, do a purge in the projects where you
> need it (e.g. `make Project/purge`) in order for CMake to pick it up.

> __Note:__ Data packages are put under either `DBASE` or `PARAM`, depending on a
> predefined list. The location does not affect the builds in any way.

### Use special LCG versions

LCG releases that are not installed under `/cvmfs/lhcb.cern.ch/` are picked up from
`/cvmfs/sft.cern.ch/` (see the `cmakePrefixPath` setting).

The EP-SFT groups provides cvmfs installations of
[special LCG flavours or nightly builds](http://lcginfo.cern.ch/).
For example, in order to use the `dev4` nightly build from Tuesday, it is enough to do

```sh
git -C Detector switch v0-patches  # master requires GitCondDB which is not available in the toolchain
utils/config.py lcgVersion dev4/Tue
utils/config.py cmakePrefixPath '$CMAKE_PREFIX_PATH:/cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Tue'
```

### Pass flags to CMake

In order to pass variables to CMake, you can pass `CMAKEFLAGS='-DVARIABLE=VALUE'`
when calling `make Project/configure`. This will pass the flags to `Project` but
also to any other dependent project that happens to need reconfiguring.

Alternatively, if you like to persist the flags you pass per project, set the appropriate
configuration setting, e.g.

```sh
utils/config.py -- cmakeFlags.Allen '-DSTANDALONE=OFF -DSEQUENCE=velo'
utils/config.py -- cmakeFlags.Moore '-DLOKI_BUILD_FUNCTOR_CACHE=OFF -DBUILD_FUNCTOR_CACHE=OFF'
```

or use `cmakeFlags.default` to affect all projects.

### Pass options to Ninja

To pass command line options to Ninja, you can pass the `BUILDFLAGS` variable to `make`.
For example, to override the default number of concurrent compilations to 2, run

```sh
make Rec BUILDFLAGS='-j 2'
```

### Use DetDesc

By default, dd4hep is used for the detector description. To use DetDesc it is enough to
switch to a platform with `+detdesc` added after the compiler, for example

```sh
utils/config.py binaryTag x86_64_v2-centos7-gcc11+detdesc-opt
```

### Building Gauss

### Sim11 (Gauss-on-Gaussino)

The default version of Gauss used for `lb-stack-setup` is `Sim11` (Gauss-on-Gaussino).
In order to build the whole Gauss-on-Gaussino stack, you only need to run:

```sh
make Gauss
```

If you wish to work with Gaussino only:

```sh
make Gaussino
```

More information can be found in the following documentations:
- [Gaussino](https://gaussino.docs.cern.ch/)
- [Gauss-on-Gaussino](https://lhcb-gauss.docs.cern.ch/)

#### Sim10

Older versions of Gauss need a few more steps. Below you will find an example for `Sim10`.
You can find the right tags/branches/platforms for other versions in the
[Gauss release notes](https://gitlab.cern.ch/lhcb/Gauss/-/releases).

```sh
utils/config.py binaryTag x86_64_v2-centos7-gcc11-opt
utils/config.py lcgVersion 102b
utils/config.py gitBranch.Gauss Sim10
utils/config.py gitBranch.Run2Support sim10-patches
utils/config.py gitBranch.LHCb sim10-patches
utils/config.py gitBranch.Geant4 v10r6p2t7
utils/config.py gitBranch.Gaudi v36r9p1
# if the projects were already created, then:
git -C Gauss switch Sim10
git -C Run2Support switch sim10-patches
git -C LHCb switch sim10-patches
git -C Geant4 checkout v10r6p2t7
git -C Gaudi checkout v36r9p1
# finally make Gauss
make Gauss
```

### Build a run2-patches stack

```sh
curl -sSL https://gitlab.cern.ch/lhcb-core/dev-tools/lb-stack-setup/raw/master/setup.py | python3 - run2-stack
cd run2-stack
utils/config.py gitBranch.default run2-patches
make DaVinci
```

### Reproduce nightly builds

Some projects might require some MRs to be applied on top
of the default branch used in the nightlies. This is reflected in the nightly
slot definitions (by using HEAD as version) and you can see the exact set of
MRs applied at the project's checkout page of a given build.

Below are two examples of how to get a checkout of Gauss that corresponds to the
`lhcb-master/1767` build (which included MRs 845 and 861).

#### Checkout and apply MRs manually

```sh
cd Gauss
git fetch && git fetch origin '+refs/merge-requests/*/head:refs/remotes/origin/mr/*'
git checkout origin/master
git merge --no-edit origin/mr/845 origin/mr/861
```

#### Checkout the nightly tags

The nightlies create a tag for each project and for each build. These tags can be used as follows

```sh
cd Gauss
git fetch ssh://git@gitlab.cern.ch:7999/lhcb-nightlies/Gauss.git lhcb-master/1767
git checkout FETCH_HEAD
```

### Update the setup

In case there is a fix or an update to the setup, just run `setup.py`

```sh
python3 utils/setup.py
```

It attempts to pull the latest `master` and to update your `config.json`.
Then, verify your configuration (to catch issues with new or modified settings).

```sh
utils/config.py
```

Finally, try to build again and follow any instructions you may get.
If that is not sufficient (e.g. because the toolchain changed),
the best is to purge all your projects with

```sh
make purge
```

### Use a non-standard branch of lb-stack-setup

You might want to use a branch other than `master` to try out a new feature
that is not merged yet.

If you start from scratch, you can normally just tweak the way you run
`setup.py`. For example, if you want to try out a branch called `vscode`, do

```sh
curl -sSL https://gitlab.cern.ch/lhcb-core/dev-tools/lb-stack-setup/raw/master/setup.py | \
    python3 - stack -b vscode
```

> __Note:__ In some rare cases, you might need to download `setup.py` not from
> `master` but from the branch in question.

If you already have a stack set up, first check out the branch you want in utils

```sh
cd utils
git fetch
git checkout vscode
```

then, rerun `setup.py`, giving the same branch name, so that your existing
configuration is made consistent with the new branch.

```sh
./setup.py -b vscode
```

### Develop lb-stack-setup

Once you have a clone of this repo (e.g. the `stack/utils` directory), you can run

```sh
python3 setup.py --repo . path/to/new/stack
```

which will use the `HEAD` (i.e. the currently checked out branch) of your local
repo to create a new stack setup at the given path.
Note that uncommitted changes will not be in the new clone.

### Use custom toolchains (LbDevTools and lcg-toolchains)

If you need to debug the toolchain, or use a custom version, you can do so by
cloning LbDevTools and prepending the path to the cmake directory to `cmakePrefixPath`:

```sh
git clone ssh://git@gitlab.cern.ch:7999/lhcb-core/LbDevTools.git
utils/config.py cmakePrefixPath "$(pwd)/LbDevTools/LbDevTools/data/cmake:\$CMAKE_PREFIX_PATH"
```

To use a local copy of the new-style CMake toolchains (currently only for Gaudi),
simply clone the repository in the stack directory:

```sh
git clone ssh://git@gitlab.cern.ch:7999/lhcb-core/lcg-toolchains.git
```

### Migrate from another stack setup

- Follow the [Get started](#get-started) instructions and stop before compiling.
- Copy your existing projects in the stack directory, where each project goes in
  a folder with the standard letter case found on GitLab (e.g. LHCb, Lbcom, Rec).
- Run `make purge` to delete all existing build products. Your code is safe.
- Run `make`. Required projects that you don't have (like Gaudi) will be
  cloned for you.

### Pass flags to docker

When running in docker, you might want to pass flags to the LHCb docker wrapper
`lb-docker-run`. You can do that by setting the `LB_DOCKER_RUN_FLAGS` environment
variable. For example, to mount the directory `/some/path` you would do

```sh
LB_DOCKER_RUN_FLAGS="-v /some/path" Moore/run gaudirun.py ...
```

### Troubleshooting

1. Check your configuration files `utils/config.json` and `utils/default-config.json`.
   Check how they are interpreted by running `utils/config.py`.
2. Check the content of your output directory (by default this is `.output`) and
   in particular look into
   - the log at `.output/log`
   - the host environment (in which you run `make`): `.output/host.env`
   - the LHCb "build-env" environment (in which `make.sh` is run):
     `.output/make.sh.env`
   - the compilation environment (in which `project.mk` is invoked):
     `.output/project.mk.env`
3. To see in detail what ninja executes, use `make Project VERBOSE=1`.

If you fixed it, great! If you think it's possible that someone else hits the
same problem, plese [open an issue](/../../issues/new) or submit a merge request.

If you couldn't figure it out, seek help on
[Mattermost](https://mattermost.web.cern.ch/lhcb/channels/core-software)
or open an [open an issue](/../../issues/new), ideally provinding steps to
reproduce the problem.

## Known issues

- VSCode integration
  - A `C/C++ Configuration Warnings` output window may appear once per session
    to tell you that compile_commands for some projects are not up-to-date.
    Build them in order not to get the warnings
- You MUST run the top-level `make` from the directory where it resides.
- Need to be able to run docker without sudo.
- distcc is not happy about some of our generated files (can be ignored)

    ```log
    distcc[2541] (dcc_talk_to_include_server) Warning: include server gave up analyzing
    distcc[2541] (dcc_build_somewhere) Warning: failed to get includes from include server, preprocessing locally
    ```

- Exception from xenv (LbEnv/1020): this is a race condition when creating the xenvc cache, just retry the build.

    ```log
    _pickle.UnpicklingError: pickle data was truncated
    ```

- [GitLab issues](/../../issues)